### PR TITLE
Added Markdown Image Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,45 @@
-*.pyc
+# Cache files
 ~*.*
 *.*~
-*.egg
-*.egg-info
-dist
-build
-eggs
 
-# Virtual Environments
-env
-.env
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+.env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 dist
 build
 eggs
+
+# Virtual Environments
+env
+.env

--- a/README.md
+++ b/README.md
@@ -103,6 +103,34 @@ Secretary allows you to use placeholder images in templates that will be replace
 > To change image name, right click under image, select "Picture..." from the popup menu and navigate to
 "Options" tab.
 
+
+### Image Markdown Support
+
+It is also possible to use `markdown` filter to put Images into your template file. for example:
+
+
+```python
+from secretary import Renderer
+
+engine = Renderer()
+
+res=engine.render('simple_template.odt',
+                  document=dict(md_sample="\n\n![writer.png](samples/images/writer.png)\n\n "))
+with open('rendered_document.odt', 'wb') as f:
+    f.write(res)
+```
+
+To resize the inserted image properly, **Open Document Format** uses `inch` unit over `pixel`! to convert image's size from pixels to inch, you need to know the dpi of the device you're working with. the default value for dpi is set to 200, but you can change it by passing a `_dpi` value to render method.
+
+```python
+# set Image's dpi to 300
+res=engine.render('simple_template.odt',
+                  _dpi=300))
+with open('rendered_document.odt', 'wb') as f:
+    f.write(res)
+```
+
+
 #### Media loader
 To load image data, Secretary needs a media loader. The engine by default provides a file system loader which takes the variable value (specified in image name). This value can be a file object containing an image or an absolute or a relative filename to `media_path` passed at `Renderer` instance creation.
 

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -124,4 +124,8 @@ transform_map = {
     'li': {
         'replace_with': 'text:list-item'
     },
+    
+    'img': {
+        'replace_with': 'draw:frame'
+    }
 }

--- a/secretary.py
+++ b/secretary.py
@@ -700,7 +700,6 @@ class Renderer(object):
 
                 # Tra
                 if tag == 'img':
-                    print('HERE')
                     image_src = html_node.getAttribute('src')
                     # register image to be Transfered later using propper media loader.
                     _key = self.image_filter(image_src)
@@ -709,7 +708,6 @@ class Renderer(object):
                     # draw:frame needs a child `draw:image` node
                     odt_child = xml_object.createElement('draw:image')
                     odt_node.appendChild(odt_child)
-                    continue
                 
                 # Transfer child nodes
                 if html_node.hasChildNodes():

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.7',
+    version='0.2.8',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.8',
+    version='0.2.8-rc1',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/test_secretary.py
+++ b/test_secretary.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import re
 import os
 from xml.dom.minidom import getDOMImplementation
-from unittest import TestCase
+from unittest import TestCase, main
 from secretary import UndefinedSilently, pad_string, Renderer
 
 def test_undefined_silently():
@@ -75,3 +76,34 @@ class RenderTestCase(TestCase):
     def test_create_text_span_node(self):
         assert self.engine.create_text_span_node(self.document, 'text').toxml() == '<text:span>text</text:span>'
 
+class MarkdownFilterTestCase(TestCase):
+    def setUp(self):
+        self.engine = Renderer()
+        self.engine.template_images = {}
+
+    def test_paragraphs(self):
+        test_samples = {
+            'hello\n\n\nworld\n': 2,
+            'hello world': 1,
+        }
+        pattern = r'<text:p text:style-name="Standard">[a-z ]+</text:p>'
+        for test, occurances in test_samples.items():
+            result = self.engine.markdown_filter(test)
+            found = re.findall(pattern , result)
+            assert len(found) == occurances
+    
+    def test_images(self):
+        test_samples = {
+            'Hello world ![sample](samples/images/writer.png)\n': 1,
+            '![sample](samples/images/writer.png)\n': 1,
+            '![sample](samples/images/writer.png)\n![sample](samples/images/writer.png)\n': 2,
+        }
+        pattern = '<draw:frame draw:name="[0-9a-z]+"><draw:image/></draw:frame>'
+        for test, occurances in test_samples.items():
+            result = self.engine.markdown_filter(test)
+            found = re.findall(pattern , result)
+            assert len(found) == occurances
+    
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi, I just added image support for `markdown` filter which for my work was very essential. I hope we can work around to find a way to push the changes to your repo to be more publicly available.

The Only thing that I'm not very happy about my design is it uses a `_dpi` configuration value. apparently ODF uses inch unit over pixel and the only way to resize images (width/height) from markdown to ODT with proper inch values is to use a default dpi which derived from my understanding of dpi concept. Anyhow, i used the dpi of 200 which seemed fine by my tests and offered a customize `_dpi` configuration for other values! 

```python
res=engine.render('simple_template.odt',
                  _dpi=300))
```

I explained it [Here](https://github.com/bijanebrahimi/secretary/tree/development#image-markdown-support) as well!
