### PR TITLE
Added Markdown Image Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,45 @@
-*.pyc
+# Cache files
 ~*.*
 *.*~
-*.egg
-*.egg-info
-dist
-build
-eggs
 
-# Virtual Environments
-env
-.env
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+.env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*

--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ Convert the value, a markdown formated string, into a ODT formated text. Example
 
         {{ invoice.description|markdown }}
 
+
+Supported elements are:
+
+* Headings
+* links
+* paragraphs
+* Bold, Italic, Strong, ...
+* image
+* lists (Ordered/Unordered)
+* Code
+* Footnotes
+
+
 - **pad(value, length)**
 Pad zeroes to `value` to the left until output value's length be equal to `length`. Default length if 5. Example:
 

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 
 from random import randint
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    OrderedDict = dict
 # Transform map used by the markdown filter. transform_map have
 # instructions of how to transform a HTML style tag into a ODT document
 # styled tag. Some ODT tags may need extra attributes; these are defined
@@ -112,7 +115,7 @@ def transform_sup(renderer, xml_object, html_node):
 # Some Elements should be transfermed before others (like footnotes) by using OrderedDict.
 transform_map = OrderedDict([
     ('sup', {
-        'replace_with': transform_sup,
+        'replace_with': 'transform_sup',
     }),
     
     ('div', {

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from random import randint
-
+from collections import OrderedDict
 # Transform map used by the markdown filter. transform_map have
 # instructions of how to transform a HTML style tag into a ODT document
 # styled tag. Some ODT tags may need extra attributes; these are defined
@@ -50,6 +50,8 @@ common_styles = {
 }
 
 def transform_img(renderer, xml_object, html_node):
+    """Transforms img tag to ODF draw:frame xml object.
+    """
     # register image to be Transfered later using propper media loader.
     image_src = html_node.getAttribute('src')
     image_key = renderer.image_filter(image_src)
@@ -62,83 +64,136 @@ def transform_img(renderer, xml_object, html_node):
     frame_node.appendChild(frame_child)
     return frame_node
 
-transform_map = {
-	'a': {
+def transform_ol(renderer, xml_object, html_node):
+    """Transforms ol tag with class `footnotes` and all the links with
+    href value like #fn-* to ODF footnotes xml object.
+    """
+    if html_node.getAttribute('class') == 'footnotes':
+        for child in html_node.getElementsByTagName('ol')[0].childNodes:
+            child_id = child.getAttribute('id')
+            child_numeric = child_id[3:]
+            child_text = child.firstChild.firstChild.nodeValue
+            
+            footnote_node = xml_object.createElement('text:note')
+            footnote_node.setAttribute('text:note-class', 'footnote')
+            footnote_node.setAttribute('text:id', child_id)
+            
+            footnote_citaction = xml_object.createElement('text:note-citation')
+            footnote_citaction.appendChild(xml_object.createTextNode(child_numeric))
+            footnote_node.appendChild(footnote_citaction)
+            
+            footnote_body = xml_object.createElement('text:note-body')
+            footnote_p = xml_object.createElement('text:p')
+            footnote_p.appendChild(xml_object.createTextNode(child_text))
+            footnote_body.appendChild(footnote_p)
+            
+            footnote_node.appendChild(footnote_body)
+            element = xml_object.getElementsByTagName('a')
+            for element in xml_object.getElementsByTagName('a'):
+                if element.getAttribute('href') == '#%s' % child_id:
+                    el_parent = element.parentNode
+                    element.parentNode.insertBefore(footnote_node, element)
+                    element.parentNode.removeChild(element)
+            
+        html_node.parentNode.removeChild(html_node)
+
+def transform_sup(renderer, xml_object, html_node):
+    """Removes HTML sup tags with `footnote-ref` class name. it's part of creating footnote process.
+    """
+    if html_node.getAttribute('class') == 'footnote-ref':
+        node_child = html_node.firstChild
+        node_parent = html_node.parentNode
+        
+        # FIXME: remove sup without it's Child node
+        #~ html_node.parentNode.appendChild(html_node.firstChild)
+        html_node.parentNode.insertBefore(html_node.firstChild, html_node)
+        html_node.parentNode.removeChild(html_node)
+
+# Some Elements should be transfermed before others (like footnotes) by using OrderedDict.
+transform_map = OrderedDict([
+    ('sup', {
+        'replace_with': transform_sup,
+    }),
+    
+    ('div', {
+        'replace_with': transform_ol,
+    }),
+    ('ol', {
+        'replace_with': 'text:list',
+        'attributes': {
+            'xml:id': 'list' + str(randint(100000000000000000,900000000000000000))
+        }
+    }),
+	
+    ('a', {
 		'replace_with': 'text:a',
 		'attributes': {
 			'xlink:type': 'simple',
 			'xlink:href': ''
 		}
-	},
+	}),
 
-    'p': common_styles['p'],
-    'strong': common_styles['strong'],
-    'em': common_styles['italic'],
-    'b': common_styles['strong'],
-    'i': common_styles['italic'],
+    ('p', common_styles['p']),
+    ('strong', common_styles['strong']),
+    ('em', common_styles['italic']),
+    ('b', common_styles['strong']),
+    ('i', common_styles['italic']),
 
     # Heading Styles (Use styles defined in the document)
-    'h1': {
+    ('h1', {
         'replace_with': 'text:p',
         'style_attributes': {
             'style-name': 'Heading_20_1'
         }
-    },
+    }),
 
-    'h2': {
+    ('h2', {
         'replace_with': 'text:p',
         'style_attributes': {
             'style-name': 'Heading_20_2'
         }
-    },
+    }),
 
-    'h3': {
+    ('h3', {
         'replace_with': 'text:p',
         'style_attributes': {
             'style-name': 'Heading_20_3'
         }
-    },
+    }),
 
-    'h4': {
+    ('h4', {
         'replace_with': 'text:p',
         'style_attributes': {
             'style-name': 'Heading_20_4'
         }
-    },
+    }),
 
-    'pre': {
+    ('pre', {
         'replace_with': 'text:p',
         'style_attributes': {
             'style-name': 'Preformatted_20_Text'
         }
-    },
+    }),
 
-    'code': {
+    ('code', {
         'replace_with': 'text:span',
         'style_attributes': {
             'style-name': 'Preformatted_20_Text'
         }
-    },
+    }),
 
-    'ul': {
+    ('ul', {
         'replace_with': 'text:list',
         'attributes': {
             'xml:id': 'list' + str(randint(100000000000000000,900000000000000000))
         }
-    },
+    }),
 
-    'ol': {
-        'replace_with': 'text:list',
-        'attributes': {
-            'xml:id': 'list' + str(randint(100000000000000000,900000000000000000))
-        }
-    },
-
-    'li': {
+    ('li', {
         'replace_with': 'text:list-item'
-    },
+    }),
     
-    'img': {
+    ('img', {
         'replace_with': transform_img
-    }
-}
+    })
+])

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -49,6 +49,19 @@ common_styles = {
     }
 }
 
+def transform_img(renderer, xml_object, html_node):
+    # register image to be Transfered later using propper media loader.
+    image_src = html_node.getAttribute('src')
+    image_key = renderer.image_filter(image_src)
+    
+    frame_node = xml_object.createElement('draw:frame')
+    frame_node.setAttribute('draw:name', image_key)
+    
+    # draw:frame needs a child `draw:image` node
+    frame_child = xml_object.createElement('draw:image')
+    frame_node.appendChild(frame_child)
+    return frame_node
+
 transform_map = {
 	'a': {
 		'replace_with': 'text:a',
@@ -126,6 +139,6 @@ transform_map = {
     },
     
     'img': {
-        'replace_with': 'draw:frame'
+        'replace_with': transform_img
     }
 }

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -115,7 +115,7 @@ def transform_sup(renderer, xml_object, html_node):
 # Some Elements should be transfermed before others (like footnotes) by using OrderedDict.
 transform_map = OrderedDict([
     ('sup', {
-        'replace_with': 'transform_sup',
+        'replace_with': transform_sup,
     }),
     
     ('div', {

--- a/secretary.py
+++ b/secretary.py
@@ -700,7 +700,6 @@ class Renderer(object):
 
                 # Tra
                 if tag == 'img':
-                    print('HERE')
                     image_src = html_node.getAttribute('src')
                     # register image to be Transfered later using propper media loader.
                     _key = self.image_filter(image_src)
@@ -709,7 +708,6 @@ class Renderer(object):
                     # draw:frame needs a child `draw:image` node
                     odt_child = xml_object.createElement('draw:image')
                     odt_node.appendChild(odt_child)
-                    continue
                 
                 # Transfer child nodes
                 if html_node.hasChildNodes():

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.7',
+    version='0.2.8',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.9-rc2',
+    version='0.2.9-rc3',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.8-rc1',
+    version='0.2.9-rc1',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.8',
+    version='0.2.8-rc1',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PyTest(TestCommand):
 
 setup(
     name='secretary',
-    version='0.2.9-rc1',
+    version='0.2.9-rc2',
     url='https://github.com/christopher-ramirez/secretary',
     license='MIT',
     author='Christopher Ramírez',

--- a/test_secretary.py
+++ b/test_secretary.py
@@ -104,6 +104,14 @@ class MarkdownFilterTestCase(TestCase):
             found = re.findall(pattern , result)
             assert len(found) == occurances
     
+    def test_footnotes(self):
+        test_samples = {
+            'hello world. [^1]\n\n[^1]: referenced.\n\n': '<text:p text:style-name="Standard">hello world. <text:note text:id="fn-1" text:note-class="footnote"><text:note-citation>1</text:note-citation><text:note-body><text:p>referenced. </text:p></text:note-body></text:note></text:p>',
+            'foo. [^1]\n bar. [^2] \n\n[^1]: referenced by foo.\n[^2]: referenced by bar\n': '<text:p text:style-name="Standard">foo. <text:note text:id="fn-1" text:note-class="footnote"><text:note-citation>1</text:note-citation><text:note-body><text:p>referenced by foo. </text:p></text:note-body></text:note> bar. <text:note text:id="fn-2" text:note-class="footnote"><text:note-citation>2</text:note-citation><text:note-body><text:p>referenced by bar </text:p></text:note-body></text:note> </text:p>',
+            }
+        for test, expected in test_samples.items():
+            result = self.engine.markdown_filter(test)
+            assert expected in result
 
 if __name__ == '__main__':
     main()

--- a/test_secretary.py
+++ b/test_secretary.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import re
 import os
 from xml.dom.minidom import getDOMImplementation
-from unittest import TestCase
+from unittest import TestCase, main
 from secretary import UndefinedSilently, pad_string, Renderer
 
 def test_undefined_silently():
@@ -75,3 +76,34 @@ class RenderTestCase(TestCase):
     def test_create_text_span_node(self):
         assert self.engine.create_text_span_node(self.document, 'text').toxml() == '<text:span>text</text:span>'
 
+class MarkdownFilterTestCase(TestCase):
+    def setUp(self):
+        self.engine = Renderer()
+        self.engine.template_images = {}
+
+    def test_paragraphs(self):
+        test_samples = {
+            'hello\n\n\nworld\n': 2,
+            'hello world': 1,
+        }
+        pattern = r'<text:p text:style-name="Standard">[a-z ]+</text:p>'
+        for test, occurances in test_samples.items():
+            result = self.engine.markdown_filter(test)
+            found = re.findall(pattern , result)
+            assert len(found) == occurances
+    
+    def test_images(self):
+        test_samples = {
+            'Hello world ![sample](samples/images/writer.png)\n': 1,
+            '![sample](samples/images/writer.png)\n': 1,
+            '![sample](samples/images/writer.png)\n![sample](samples/images/writer.png)\n': 2,
+        }
+        pattern = '<draw:frame draw:name="[0-9a-z]+"><draw:image/></draw:frame>'
+        for test, occurances in test_samples.items():
+            result = self.engine.markdown_filter(test)
+            found = re.findall(pattern , result)
+            assert len(found) == occurances
+    
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi, I just added image support for `markdown_filter` which for my work was very essential. I hope we can work around to find a way to push the changes to your repo to be more publicly available.

The Only thing that I'm not very happy about my design is it uses a `_dpi` configuration value. apparently ODF uses inch unit over pixel and the only way to resize images (width/height) from markdown to ODT with proper inch values is to use a default dpi which derived from my understanding of dpi concept. Anyhow, i used the dpi of 200 which seemed fine by my tests and offered a customize `_dpi` configuration for other values! 

```python
res=engine.render('simple_template.odt',
                  _dpi=300))
```

I explained it [Here](https://github.com/bijanebrahimi/secretary/tree/development#image-markdown-support) as well!
