### PR TITLE
New features for markdown filter

### DIFF
--- a/markdown_map.py
+++ b/markdown_map.py
@@ -58,6 +58,14 @@ transform_map = {
 		}
 	},
 
+	'img': {
+		'replace_with': 'draw:frame',
+		'attributes': {
+			'svg:width':'100%',
+			'style:rel-height':'scale'
+		}
+	},
+
     'p': common_styles['p'],
     'strong': common_styles['strong'],
     'em': common_styles['italic'],

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -124,4 +124,40 @@ transform_map = {
     'li': {
         'replace_with': 'text:list-item'
     },
+
+    'table': {
+		'replace_with': 'table:table',
+		'attributes': {
+			'table:name': 'Table' + str(randint(100000000000000000,900000000000000000)),
+		}
+	},
+	'thead': {
+		'replace_with': 'table:table-header-rows',
+		'attributes': {
+		}
+	},
+	'tbody': {
+		'replace_with': 'table:table-rows',
+		'attributes': {
+		}
+	},
+	'tr': {
+		'replace_with': 'table:table-row',
+		'attributes': {
+		}
+	},
+	'td': {
+		'replace_with': 'table:table-cell',
+		'attributes': {
+			'table:style-name': '',
+			'office:value-type': "string"
+		}
+	},
+	'th': {
+		'replace_with': 'table:table-cell',
+		'attributes': {
+			'table:style-name': '',
+			'office:value-type': "string"
+		}
+	},
 }

--- a/markdown_map.py
+++ b/markdown_map.py
@@ -61,8 +61,7 @@ transform_map = {
 	'img': {
 		'replace_with': 'draw:frame',
 		'attributes': {
-			'svg:width':'100%',
-			'style:rel-height':'scale'
+			'text:anchor-type': 'as-char'
 		}
 	},
 

--- a/secretary.py
+++ b/secretary.py
@@ -704,6 +704,11 @@ class Renderer(object):
         except ImportError:
             raise SecretaryError('Could not import markdown2 library. Install it using "pip install markdown2"')
 
+        # Escape XML special characters : & < >
+        markdown_text = markdown_text.replace('<', '&lt;')
+        markdown_text = markdown_text.replace('>', '&gt;')
+        markdown_text = markdown_text.replace('&', '&amp;')
+
         styles_cache = {}   # cache styles searching
         html_text = markdown(markdown_text)
         xml_object = parseString('<html>%s</html>' % html_text.encode('ascii', 'xmlcharrefreplace'))

--- a/secretary.py
+++ b/secretary.py
@@ -758,6 +758,31 @@ class Renderer(object):
                             odt_node.setAttribute('xlink:href',
                                 html_node.getAttribute('href'))
 
+                if tag == 'img':
+                    # Insert <draw:image> tag into the frame tag
+                    image_node = self.create_node(xml_object,
+                                                  'draw:image',
+                                                  parent=odt_node)
+                    # Set attributes of <draw:image>
+                    image_node.setAttribute('xlink:type', 'simple')
+                    image_node.setAttribute('xlink:show', 'embed')
+                    image_node.setAttribute('xlink:actuate', 'onLoad')
+                    if html_node.hasAttribute('src'):
+                        # All of the pictures are stored in the "Pictures"
+                        # archive folder (see add_media_to_archive())
+                        image_name = html_node.getAttribute('src').split('/')[-1]
+                        image_node.setAttribute('xlink:href',
+                                                'Pictures/' + image_name)
+
+                    # Add picture to the archive
+                    # href should contain absolute or relative path to local image
+                    # name argument must not contain the extension
+                    pic = self.media_callback(html_node.getAttribute('src'))
+                    import ipdb; ipdb.set_trace()
+                    self.add_media_to_archive(media = pic[0],
+                                              mime = pic[1],
+                                              name = path.splitext(image_name)[0])
+
                 # Does the node need to create a style?
                 if 'style' in transform_map[tag]:
                     name = transform_map[tag]['style']['name']


### PR DESCRIPTION
These commits are mainly introducing **table** and **images** management for the markdown filter.

A few things that you may not like:

- Special characters escaping seems to be buggy... Characters are not correctly converted in the final document.
- Manual creation of unique style for each element of a table is not necessary as it is automatically done by LibreOffice if there is not. It means that several pieces of code are useless.
- Images are working fine but it uses **PIL** (it seems there some problems with it ?)

If you have any idea to improve these issues, I'll take it !