### PR TITLE
Add conversion for line breaks tag br to tag text:line-break

### DIFF
--- a/markdown_map.py
+++ b/markdown_map.py
@@ -124,4 +124,8 @@ transform_map = {
     'li': {
         'replace_with': 'text:list-item'
     },
+
+    'br': {
+        'replace_with': 'text:line-break'
+    },
 }


### PR DESCRIPTION
In markdown syntax, sigle line break should not casue line break in output document.

```markdown
A paragraph
A line break
```

This should be

```html
<p>A paragraph A line break</p>
```
and it is common mistake to expect different behavior.

Forcing line break should be done by double space at the end of line in markdown

```markdown
A paragraph<space><space>
A line break
```
will convert to

```html
<p>A paragraph <br>
A line break</p>
```

But `secretary` did not have conversion from `<br>` to `<text:line-break>` so this PR is just about it.