### PR TITLE
tags_in_document new method

### DIFF
--- a/secretary.py
+++ b/secretary.py
@@ -299,6 +299,17 @@ class Renderer(object):
                 continue
 
             yield tag
+    
+    def tags_in_document(self,template):
+        """
+            returns a list of available jinja instructions tags in template file.
+        """
+        self.files = self._unpack_template(template)
+        self.content  = parseString(self.files['content.xml'])
+        self.styles   = parseString(self.files['styles.xml'])
+        dom_tags = [*self._tags_in_document(self.content)] + [*self._tags_in_document(self.styles)]
+
+        return [tag.childNodes[0].data.strip() for tag in dom_tags]
 
 
     def _census_tags(self, document):

--- a/test_secretary.py
+++ b/test_secretary.py
@@ -66,7 +66,7 @@ class RenderTestCase(TestCase):
 
     def test_list_available_tags(self):
         print (self.engine.tags_in_document(self.template))
-        assert self.engine.tags_in_document(self.template) == []
+        assert len(self.engine.tags_in_document(self.template)) == 17
 
 
 class EscapingVariablesValues(TestCase):

--- a/test_secretary.py
+++ b/test_secretary.py
@@ -23,11 +23,11 @@ class RenderTestCase(TestCase):
     def setUp(self):
         root = os.path.dirname(__file__)
         impl = getDOMImplementation()
-        template = os.path.join(root, 'simple_template.odt')
+        self.template = os.path.join(root, 'simple_template.odt')
 
         self.document = impl.createDocument(None, "some_tag", None)
         self.engine = Renderer()
-        self.engine.render(template)
+        self.engine.render(self.template)
 
     def test__unescape_entities(self):
         test_samples = {
@@ -63,6 +63,10 @@ class RenderTestCase(TestCase):
 
     def test_create_text_span_node(self):
         assert self.engine.create_text_span_node(self.document, 'text').toxml() == '<text:span>text</text:span>'
+
+    def test_list_available_tags(self):
+        print (self.engine.tags_in_document(self.template))
+        assert self.engine.tags_in_document(self.template) == []
 
 
 class EscapingVariablesValues(TestCase):


### PR DESCRIPTION
I need to previev template tags so I proposing a public tags_in_document method with a template file as argument that make use of _tags_in_document internal method